### PR TITLE
AN-3773/add retry for missing txs

### DIFF
--- a/models/silver/retry/_missing_transactions.sql
+++ b/models/silver/retry/_missing_transactions.sql
@@ -1,0 +1,43 @@
+{{ config(
+    materialized = 'ephemeral'
+) }}
+
+WITH blocks AS (
+
+    SELECT
+        block_number,
+        block_hash,
+        tx_count
+    FROM
+        {{ ref('silver__blocks') }}
+    WHERE
+        _inserted_timestamp >= DATEADD(
+            'day',
+            -3,
+            CURRENT_DATE
+        )
+),
+transactions AS (
+    SELECT
+        block_number,
+        COUNT(
+            DISTINCT tx_id
+        ) AS tx_count
+    FROM
+        {{ ref('silver__transactions') }}
+    WHERE
+        _inserted_timestamp >= DATEADD(
+            'day',
+            -3,
+            CURRENT_DATE
+        )
+    GROUP BY
+        1
+)
+SELECT
+    b.block_number
+FROM
+    blocks b
+    LEFT JOIN transactions t USING (block_number)
+WHERE
+    b.tx_count != t.tx_count

--- a/models/silver/streamline/realtime/streamline__transactions_realtime.sql
+++ b/models/silver/streamline/realtime/streamline__transactions_realtime.sql
@@ -68,3 +68,14 @@ SELECT
     ) AS params
 FROM
     {{ ref('_pending_blocks') }}
+UNION
+SELECT
+    block_number,
+    'getblock' AS method,
+    CONCAT(
+        block_hash,
+        '_-_',
+        '2'
+    ) AS params
+FROM
+    {{ ref('_missing_transactions') }}


### PR DESCRIPTION
Adds ephemeral model to check blocks in last 3 days for missing txs & re-queries those blocks via streamline