### PR TITLE
Quickfix/update pending blocks

### DIFF
--- a/models/silver/retry/_pending_blocks.sql
+++ b/models/silver/retry/_pending_blocks.sql
@@ -16,8 +16,20 @@ WITH pending_blocks AS (
             CURRENT_DATE
         )
         AND is_pending
+),
+blocks_hash AS (
+    SELECT
+        block_number,
+        block_hash
+    FROM
+        {{ ref('streamline__complete_blocks_hash') }}
 )
 SELECT
-    *
+    block_number,
+    COALESCE(
+        p.block_hash,
+        b.block_hash
+    ) AS block_hash
 FROM
-    pending_blocks
+    pending_blocks p
+    LEFT JOIN blocks_hash b USING (block_number)


### PR DESCRIPTION
Adds in a look to the complete blocks hash model in the event `block_hash` is `null` in silver