### PR TITLE
upd _missing_transactions to incl null

### DIFF
--- a/models/silver/retry/_missing_transactions.sql
+++ b/models/silver/retry/_missing_transactions.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'ephermeral'
+    materialized = 'ephemeral'
 ) }}
 
 WITH blocks AS (

--- a/models/silver/retry/_missing_transactions.sql
+++ b/models/silver/retry/_missing_transactions.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'ephemeral'
+    materialized = 'view'
 ) }}
 
 WITH blocks AS (
@@ -42,3 +42,4 @@ FROM
     LEFT JOIN transactions t USING (block_number)
 WHERE
     b.tx_count != t.tx_count
+    OR t.tx_count IS NULL

--- a/models/silver/retry/_missing_transactions.sql
+++ b/models/silver/retry/_missing_transactions.sql
@@ -1,5 +1,5 @@
 {{ config(
-    materialized = 'view'
+    materialized = 'ephermeral'
 ) }}
 
 WITH blocks AS (


### PR DESCRIPTION
Missing the following 3 blocks in txs:
-- 806397
-- 806343
-- 806344

Was not hitting retry logic due to `null`