### PR TITLE
add date filter for just non lowered btc labels

### DIFF
--- a/models/silver/labels/silver__labels.sql
+++ b/models/silver/labels/silver__labels.sql
@@ -16,15 +16,16 @@ SELECT
     project_name
 FROM
     {{ ref('bronze__labels') }}
+WHERE
+    insert_date >= '2023-10-04'
 
 {% if is_incremental() %}
-WHERE
-    insert_date >= (
-        SELECT
-            MAX(
-                insert_date
-            )
-        FROM
-            {{ this }}
-    )
+AND insert_date >= (
+    SELECT
+        MAX(
+            insert_date
+        )
+    FROM
+        {{ this }}
+)
 {% endif %}


### PR DESCRIPTION
Adds a date filter to the labels model to only take the current labels after Graham's fix to not lower the address in his mapping algo