### PR TITLE
add incremental predicates to optimize data loads

### DIFF
--- a/models/bronze/core/bronze__transactions.sql
+++ b/models/bronze/core/bronze__transactions.sql
@@ -3,7 +3,8 @@
     cluster_by = ["_inserted_timestamp::DATE"],
     unique_key = "tx_id",
     tags = ["load"],
-    incremental_strategy = 'delete+insert'
+    incremental_strategy = 'delete+insert',
+    incremental_predicates = ['block_number >= (select min(block_number) from ' ~ generate_tmp_view_name(this) ~ ')'],
 ) }}
 -- depends_on: {{ ref('bronze__streamline_transactions') }}
 WITH streamline_transactions AS (

--- a/models/silver/core/silver__inputs.sql
+++ b/models/silver/core/silver__inputs.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
+    incremental_predicates = ['block_number >= (select min(block_number) from ' ~ generate_tmp_view_name(this) ~ ')'],
     unique_key = 'input_id',
     tags = ["core"],
     cluster_by = ["_inserted_timestamp"],

--- a/models/silver/core/silver__inputs_final.sql
+++ b/models/silver/core/silver__inputs_final.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
+    incremental_predicates = ['block_number >= (select min(block_number) from ' ~ generate_tmp_view_name(this) ~ ')'],
     unique_key = 'input_id',
     cluster_by = ["block_number", "tx_id"],
     tags = ["core"],

--- a/models/silver/core/silver__outputs.sql
+++ b/models/silver/core/silver__outputs.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
+    incremental_predicates = ['block_number >= (select min(block_number) from ' ~ generate_tmp_view_name(this) ~ ')'],
     unique_key = 'output_id',
     tags = ["core"],
     cluster_by = ["_partition_by_block_id", "tx_id"],

--- a/models/silver/core/silver__transactions.sql
+++ b/models/silver/core/silver__transactions.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
+    incremental_predicates = ['block_number >= (select min(block_number) from ' ~ generate_tmp_view_name(this) ~ ')'],
     unique_key = 'tx_id',
     cluster_by = ["_inserted_timestamp::DATE", "block_number"],
     tags = ["core"]

--- a/models/silver/core/silver__transactions_final.sql
+++ b/models/silver/core/silver__transactions_final.sql
@@ -1,6 +1,7 @@
 {{ config(
     materialized = 'incremental',
     incremental_strategy = 'delete+insert',
+    incremental_predicates = ['block_number >= (select min(block_number) from ' ~ generate_tmp_view_name(this) ~ ')'],
     unique_key = 'tx_id',
     cluster_by = ["block_number", "tx_id"],
     tags = ["core"],


### PR DESCRIPTION
- Most of the run time on incremental load is related to the `DELETE` part of the `delete+insert` performing a full-scan of the existing table for several models
  - Added incremental predicates to take advantage of the fact that `block_number` is sequential
  - This will work to prune the data even if we don't cluster by block_number because the data is still loaded sequentially 99.9% of the time so Snowflake will be able to micro-partition them automatically