### PR TITLE
Add UDF Decode Hex

### DIFF
--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -6,9 +6,7 @@
 {{ create_udf_hex_to_int(
             schema = "public"
         ) }}
-{{ create_udf_decode_hex_to_string(
-            schema = "public"
-        ) }}
+        {{ create_udf_decode_hex_to_string() }}
         {{ create_udtf_get_base_table(
             schema = "streamline"
         ) }}

--- a/macros/create_udfs.sql
+++ b/macros/create_udfs.sql
@@ -6,6 +6,9 @@
 {{ create_udf_hex_to_int(
             schema = "public"
         ) }}
+{{ create_udf_decode_hex_to_string(
+            schema = "public"
+        ) }}
         {{ create_udtf_get_base_table(
             schema = "streamline"
         ) }}

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -20,8 +20,9 @@ def hex_to_int(hex) -> str:
 $$;
 {% endmacro %}
 
-{% macro create_udf_decode_hex_to_string(schema) %}
-CREATE OR REPLACE FUNCTION {{ schema }}.UDF_DECODE_HEX_TO_STRING(hex_string STRING)
+{% macro create_udf_decode_hex_to_string() %}
+{% set sql %}
+CREATE OR REPLACE FUNCTION {{ target.database }}.STREAMLINE.UDF_DECODE_HEX_TO_STRING(hex_string STRING)
   RETURNS STRING
   LANGUAGE PYTHON
   RUNTIME_VERSION = '3.10'
@@ -45,4 +46,6 @@ def decode_hex_to_string(hex_string):
     return decode_hex_to_string(hex_string)
 
 $$;
+{% endset %}
+{% do run_query(sql) %}
 {% endmacro %}

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -42,7 +42,5 @@ def decode_hex_to_string(hex_string):
     except Exception as e:
         return str(e)
 
-    return decode_hex_to_string(hex_string)
-
 $$;
 {% endmacro %}

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -21,7 +21,6 @@ $$;
 {% endmacro %}
 
 {% macro create_udf_decode_hex_to_string() %}
-{% set sql %}
 CREATE OR REPLACE FUNCTION {{ target.database }}.STREAMLINE.UDF_DECODE_HEX_TO_STRING(hex_string STRING)
   RETURNS STRING
   LANGUAGE PYTHON
@@ -46,6 +45,4 @@ def decode_hex_to_string(hex_string):
     return decode_hex_to_string(hex_string)
 
 $$;
-{% endset %}
-{% do run_query(sql) %}
 {% endmacro %}

--- a/macros/python/udfs.sql
+++ b/macros/python/udfs.sql
@@ -19,3 +19,30 @@ def hex_to_int(hex) -> str:
   return str(int(hex, 16)) if hex else None
 $$;
 {% endmacro %}
+
+{% macro create_udf_decode_hex_to_string(schema) %}
+CREATE OR REPLACE FUNCTION {{ schema }}.UDF_DECODE_HEX_TO_STRING(hex_string STRING)
+  RETURNS STRING
+  LANGUAGE PYTHON
+  RUNTIME_VERSION = '3.10'
+  HANDLER = 'decode_hex_to_string'
+AS
+$$
+import binascii
+
+def decode_hex_to_string(hex_string):
+    """
+    This UDF decodes a hexadecimal string input into its original ASCII representation using the binascii.unhexlify function in Python. 
+    If successful, it returns the decoded message; otherwise, it handles errors and returns the error message or NULL if decoding fails.
+    The primary use-case for this function will be to decode the COINBASE message.
+    """
+    try:
+        decoded_message = binascii.unhexlify(hex_string).decode("utf-8", errors="ignore")
+        return decoded_message
+    except Exception as e:
+        return str(e)
+
+    return decode_hex_to_string(hex_string)
+
+$$;
+{% endmacro %}

--- a/models/descriptions/coinbase_decoded.md
+++ b/models/descriptions/coinbase_decoded.md
@@ -1,0 +1,5 @@
+{% docs coinbase_decoded %}
+
+The decoded coinbase message for a block, if applicable.
+
+{% enddocs %}

--- a/models/gold/gov/gov__ez_miner_rewards.sql
+++ b/models/gold/gov/gov__ez_miner_rewards.sql
@@ -15,6 +15,7 @@ SELECT
     block_timestamp,
     block_number,
     block_hash,
+    coinbase_decoded,
     total_reward,
     block_reward,
     fees,

--- a/models/gold/gov/gov__ez_miner_rewards.sql
+++ b/models/gold/gov/gov__ez_miner_rewards.sql
@@ -25,7 +25,7 @@ SELECT
             ['block_number']
         ) }}
     ) AS ez_miner_rewards_id,
-    COALESCE(inserted_timestamp, _inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) as inserted_timestamp,
-    COALESCE(modified_timestamp, _inserted_timestamp, '2000-01-01' :: TIMESTAMP_NTZ) as modified_timestamp
+    inserted_timestamp,
+    modified_timestamp
 FROM
     blocks

--- a/models/gold/gov/gov__ez_miner_rewards.yml
+++ b/models/gold/gov/gov__ez_miner_rewards.yml
@@ -29,6 +29,9 @@ models:
       - name: BLOCK_HASH
         description: "{{ doc('block_hash') }}"
 
+      - name: COINBASE_DECODED
+        description: "{{ doc('coinbase_decoded') }}"
+
       - name: TOTAL_REWARD
         description: "{{ doc('total_reward') }}"
         tests: 

--- a/models/silver/ez/silver__block_miner_rewards.sql
+++ b/models/silver/ez/silver__block_miner_rewards.sql
@@ -53,7 +53,8 @@ coinbase AS (
     SELECT
         block_number,
         coinbase,
-        output_value AS coinbase_value
+        output_value AS coinbase_value,
+        STREAMLINE.DECODE_HEX_TO_STRING(coinbase) AS coinbase_decoded
     FROM
         transactions
     WHERE
@@ -68,6 +69,7 @@ blocks_final AS (
         C.coinbase_value - v.fees AS block_reward,
         v.fees,
         C.coinbase,
+        C.coinbase_decoded,
         b._partition_by_block_id,
         b._inserted_timestamp
     FROM

--- a/models/silver/ez/silver__block_miner_rewards.sql
+++ b/models/silver/ez/silver__block_miner_rewards.sql
@@ -54,7 +54,7 @@ coinbase AS (
         block_number,
         coinbase,
         output_value AS coinbase_value,
-        STREAMLINE.DECODE_HEX_TO_STRING(coinbase) AS coinbase_decoded
+        STREAMLINE.UDF_DECODE_HEX_TO_STRING(coinbase) AS coinbase_decoded
     FROM
         transactions
     WHERE


### PR DESCRIPTION
Existing LQ UDF_HEX_DECODE_STRING uses Snowflake's TRY_HEX_DECODE_STRING() which fails to decode the COINBASE message. UDF leverages binascii.unhexlify and returns a fully decoded message to infer miner pool, where applicable.


```sql
select 
    block_number,
    coinbase,
    BITCOIN_DEV.STREAMLINE.DECODE_HEX_TO_STRING(coinbase) as coinbase_decoded
from bitcoin.core.fact_transactions
where is_coinbase
and block_timestamp > sysdate() - interval '1 day'
limit 5;
```


Example Output:


block_number | coinbase | coinbase_decoded
-- | -- | --
833436 | 039cb70c194d696e656420627920416e74506f6f6c20ea003e053fb01138fabe6d6da5fac5d6cf54117b14a9970397e5c55d1e880a11ace5b187a51a6986c3f56b3410000000000000000000cf447a4c000000000000 | Mined by AntPool >?8mmT{]屇ik4DzL
833467 | 03bbb70c043ef8e8652f466f756e6472792055534120506f6f6c202364726f70676f6c642f23bfa3ef566a000000000000 | >e/Foundry USA Pool #dropgold/#Vj
833494 | 03d6b70c2cfabe6d6d7765897d9c7e7a08a3ce8c7ca7b384e6c4d4b5d78b671f211e3f937ed383322710000000f09f909f092f4632506f6f6c2f730000000000000000000000000000000000000000000000000000000000000000000000050061010000 | ַ,mmwe}~zΌ\|Ե׋g!?~Ӄ2'🐟	/F2Pool/sa
833531 | 03fbb70c1b4d696e656420627920416e74506f6f6c393539ea0023013a0f265efabe6d6df8d614d47eb815674034bfcec1fbeea0154ebec5b904bb2fe84bb886e3ad05a510000000000000000000885e6162000000000000 | Mined by AntPool959#:&^mm~g@4NŹ/K^ab
833591 | 0337b80c194d696e656420627920416e74506f6f6c20ea001e05faf370ecfabe6d6db8ad8954ffb7678a021e5a6343932921263744bcc2573621c82a11ae78fe0e9810000000000000000000b472c0544c0000000000 | 7Mined by AntPool pmmTgZcC)!&7DW6!*xrTL

