### PR TITLE
AN-4753/new entity cluster table for fr

### DIFF
--- a/models/silver/labels/clustering/silver__full_entity_cluster.sql
+++ b/models/silver/labels/clustering/silver__full_entity_cluster.sql
@@ -117,6 +117,6 @@ SELECT
 FROM
     {{ source(
         "bitcoin_bronze",
-        "entity_clusters"
+        "ENTITY_CLUSTERS_20240414_132013"
     ) }}
 {% endif %}

--- a/models/silver/labels/clustering/silver__full_entity_cluster.sql
+++ b/models/silver/labels/clustering/silver__full_entity_cluster.sql
@@ -5,7 +5,7 @@
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['entity_cluster'],
     post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    full_refresh = False
+    full_refresh = True
 ) }}
 
 {% if is_incremental() %}

--- a/models/silver/labels/clustering/silver__full_entity_cluster.sql
+++ b/models/silver/labels/clustering/silver__full_entity_cluster.sql
@@ -4,8 +4,7 @@
     incremental_strategy = 'merge',
     merge_exclude_columns = ["inserted_timestamp"],
     tags = ['entity_cluster'],
-    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION",
-    full_refresh = True
+    post_hook = "ALTER TABLE {{ this }} ADD SEARCH OPTIMIZATION"
 ) }}
 
 {% if is_incremental() %}

--- a/models/sources.yml
+++ b/models/sources.yml
@@ -35,6 +35,7 @@ sources:
     schema: bronze
     tables:
       - name: entity_clusters
+      - name: ENTITY_CLUSTERS_20240414_132013
   - name: bitcoin_core
     database: bitcoin
     schema: core


### PR DESCRIPTION
Entity Cluster local FR copied to bronze schema with data cleaning via:

```sql
create or replace table BITCOIN.BRONZE.ENTITY_CLUSTERS_20240414_132013 as
select 
    REPLACE("address"::STRING, '"', '') as address_lower,
    f.pubkey_script_address AS address,
    "group"::bigint as group_id,
    NULL AS project_name,
    TO_TIMESTAMP("_inserted_timestamp"/1000000) AS _inserted_timestamp
from BITCOIN.CLUSTERING_RUNS.COMMON_SPEND_EDGES_20240414_132013 a
left join (select distinct pubkey_script_address from bitcoin.silver.inputs_final) f
    on REPLACE(a."address"::STRING, '"', '') = lower(f.pubkey_script_address)
;
```

This lets us run the full cluster table as a FR to load with this data.
One incremental run of 24h may not be sufficient, should extend to 2d and run today to ensure nothing is missed.

FR command:
`dbt run -s silver__full_entity_cluster silver__full_entity_cluster_label silver__transfers --full-refresh -t dev2xl `

Incremental:
`dbt run -s tag:entity_cluster_0 --vars '{"INCREMENTAL_CLUSTER_BACKFILL": True, "INCREMENTAL_CLUSTER_INTERVAL": 48}'`
`dbt run -s tag:entity_cluster --vars '{"INCREMENTAL_CLUSTER_BACKFILL": True, "INCREMENTAL_CLUSTER_INTERVAL": 48}'`
