### PR TITLE
btc/upd fsc utils to 1.23.0

### DIFF
--- a/package-lock.yml
+++ b/package-lock.yml
@@ -6,11 +6,11 @@ packages:
 - package: dbt-labs/dbt_utils
   version: 1.0.0
 - git: https://github.com/FlipsideCrypto/fsc-utils.git
-  revision: c84d623aa09ce2acb9451e6aedf5fa70c19b0b95
+  revision: 484e9db07d2060286768bb745e1b0e879178d43b
 - package: get-select/dbt_snowflake_query_tags
-  version: 2.3.2
+  version: 2.3.3
 - package: calogica/dbt_date
   version: 0.7.2
 - git: https://github.com/FlipsideCrypto/livequery-models.git
-  revision: bca494102fbd2d621d32746e9a7fe780678044f8
-sha1_hash: ce25373a314499826f1bef1d1fca885141e945e9
+  revision: b024188be4e9c6bc00ed77797ebdc92d351d620e
+sha1_hash: 5b45e0f95979d82d85fd603d44f5bf35be9a7064

--- a/packages.yml
+++ b/packages.yml
@@ -6,6 +6,6 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
   - git: https://github.com/FlipsideCrypto/fsc-utils.git
-    revision: v1.11.0
+    revision: v1.23.0
   - package: get-select/dbt_snowflake_query_tags
     version: [">=2.0.0", "<3.0.0"]


### PR DESCRIPTION
`dbt run -s livequery_models.deploy.marketplace.github --vars '{UPDATE_UDFS_AND_SPS: true}'`