### PR TITLE
add better backfill logic to clusters

### DIFF
--- a/models/silver/labels/clustering/silver__incremental_base_clusters.sql
+++ b/models/silver/labels/clustering/silver__incremental_base_clusters.sql
@@ -28,6 +28,14 @@ WHERE
       pubkey_script_address
     FROM
       {{ ref('silver__inputs_final') }}
+    {% if var(
+        'INCREMENTAL_CLUSTER_BACKFILL',
+        False
+      ) %}
+    WHERE
+      _inserted_timestamp BETWEEN '{{ var('INCREMENTAL_CLUSTER_BACKFILL_START') }}' :: timestamp_ntz
+      AND '{{ var('INCREMENTAL_CLUSTER_BACKFILL_END') }}' :: timestamp_ntz
+    {% else %}
     WHERE
       _inserted_timestamp BETWEEN (
         SELECT
@@ -41,6 +49,7 @@ WHERE
         FROM
           date_range
       )
+    {% endif %}
   )
 GROUP BY
   address_group


### PR DESCRIPTION
`dbt run -s tag:entity_cluster_0 --vars '{"INCREMENTAL_CLUSTER_BACKFILL": True, "INCREMENTAL_CLUSTER_BACKFILL_START": "2024-04-15T00:00:00Z", "INCREMENTAL_CLUSTER_BACKFILL_END": "2024-04-22T23:59:59Z"}'`

`dbt run -s tag:entity_cluster`

`dbt run -s silver__transfers --full-refresh`