### PR TITLE
AN-4771/pt 1 - Block Inscription Count Model

### DIFF
--- a/.github/workflows/dbt_run_hiro_api.yml
+++ b/.github/workflows/dbt_run_hiro_api.yml
@@ -1,5 +1,5 @@
-name: dbt_run_inscription_count
-run-name: dbt_run_inscription_count
+name: dbt_run_hiro_api
+run-name: dbt_run_hiro_api
 
 on:
   workflow_dispatch:

--- a/.github/workflows/dbt_run_inscription_count.yml
+++ b/.github/workflows/dbt_run_inscription_count.yml
@@ -1,0 +1,99 @@
+name: dbt_run_inscription_count
+run-name: dbt_run_inscription_count
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs every 15 minutes
+    - cron: '*/15 * * * *'
+
+env:
+  USE_VARS: "${{ vars.USE_VARS }}"
+  DBT_PROFILES_DIR: "${{ vars.DBT_PROFILES_DIR }}"
+  DBT_VERSION: "${{ vars.DBT_VERSION }}"
+  ACCOUNT: "${{ vars.ACCOUNT }}"
+  ROLE: "${{ vars.ROLE }}"
+  USER: "${{ vars.USER }}"
+  PASSWORD: "${{ secrets.PASSWORD }}"
+  REGION: "${{ vars.REGION }}"
+  DATABASE: "${{ vars.DATABASE }}"
+  WAREHOUSE: "${{ vars.WAREHOUSE }}"
+  SCHEMA: "${{ vars.SCHEMA }}"
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  dbt:
+    runs-on: ubuntu-latest
+    environment:
+      name: workflow_prod
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: install dependencies
+        run: |
+          pip install -r requirements.txt
+          dbt deps
+
+      - name: Block Inscription Count Request 1
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 2
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 3
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 4
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 5
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 6
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 7
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 8
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 9
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Block Inscription Count Request 10
+        run: >
+          dbt run -s dbt_run_inscription_count
+        continue-on-error: true
+
+      - name: Store logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: dbt-logs
+          path: |
+            logs
+            target

--- a/models/silver/nft/silver__block_inscription_count.sql
+++ b/models/silver/nft/silver__block_inscription_count.sql
@@ -27,13 +27,13 @@ AND (
         FROM
             {{ this }}
     )
-    OR block_number > (
+    OR block_number >= (
         SELECT
-            MAX(block_number)
+            MIN(block_number)
         FROM
             {{ this }}
         WHERE
-            status_code = 200
+            status_code != 200
     )
 )
 {% endif %}

--- a/models/silver/nft/silver__block_inscription_count.sql
+++ b/models/silver/nft/silver__block_inscription_count.sql
@@ -56,8 +56,9 @@ get_inscription_count AS (
                 'Accept',
                 'application/json',
                 'x-hiro-api-key',
-                'db2c8f0f3262113265682c15636bc775' -- TODO move to vault
-            )
+                '{x-hiro-api-key}'
+            ),
+            'vault/prod/bitcoin/hiro'
         ) AS response
     FROM
         blocks

--- a/models/silver/nft/silver__block_inscription_count.sql
+++ b/models/silver/nft/silver__block_inscription_count.sql
@@ -40,7 +40,7 @@ AND (
 ORDER BY
     block_number ASC
 LIMIT
-    100
+    100 -- rpm limit
 ),
 get_inscription_count AS (
     SELECT
@@ -52,13 +52,7 @@ get_inscription_count AS (
             'GET',
             'https://api.hiro.so/ordinals/v1/inscriptions/transfers?block=' || block_hash || '&limit=1',
             {},
-            OBJECT_CONSTRUCT(
-                'Accept',
-                'application/json',
-                'x-hiro-api-key',
-                '{x-hiro-api-key}'
-            ),
-            'vault/prod/bitcoin/hiro'
+            {}
         ) AS response
     FROM
         blocks
@@ -68,6 +62,8 @@ SELECT
     block_hash,
     response :data :total :: NUMBER AS inscription_count,
     response :status_code :: NUMBER AS status_code,
+    response,
+    response :headers ::VARIANT as headers,
     _request_timestamp,
     _modified_timestamp,
     SYSDATE() AS inserted_timestamp,

--- a/models/silver/nft/silver__block_inscription_count.sql
+++ b/models/silver/nft/silver__block_inscription_count.sql
@@ -12,10 +12,7 @@ WITH blocks AS (
     SELECT
         block_number,
         block_hash,
-        COALESCE(
-            modified_timestamp,
-            _inserted_timestamp
-        ) AS _modified_timestamp
+        _inserted_timestamp
     FROM
         {{ ref('silver__blocks') }}
     WHERE
@@ -24,9 +21,9 @@ WITH blocks AS (
 
 {% if is_incremental() %}
 AND (
-    _modified_timestamp >= (
+    _inserted_timestamp >= (
         SELECT
-            MAX(_modified_timestamp)
+            MAX(_inserted_timestamp)
         FROM
             {{ this }}
     )

--- a/models/silver/nft/silver__block_inscription_count.sql
+++ b/models/silver/nft/silver__block_inscription_count.sql
@@ -62,8 +62,6 @@ SELECT
     block_hash,
     response :data :total :: NUMBER AS inscription_count,
     response :status_code :: NUMBER AS status_code,
-    response,
-    response :headers ::VARIANT as headers,
     _request_timestamp,
     _modified_timestamp,
     SYSDATE() AS inserted_timestamp,

--- a/models/silver/nft/silver__block_inscription_count.sql
+++ b/models/silver/nft/silver__block_inscription_count.sql
@@ -40,7 +40,7 @@ AND (
 ORDER BY
     block_number ASC
 LIMIT
-    100 -- rpm limit
+    100
 ),
 get_inscription_count AS (
     SELECT

--- a/models/silver/nft/silver__block_inscription_count.sql
+++ b/models/silver/nft/silver__block_inscription_count.sql
@@ -1,0 +1,76 @@
+{{ config(
+    materialized = 'incremental',
+    incremental_strategy = 'merge',
+    merge_exclude_columns = ["inserted_timestamp"],
+    unique_key = 'block_hash',
+    cluster_by = ["block_number"],
+    tags = ["ordhook"]
+) }}
+
+WITH blocks AS (
+
+    SELECT
+        block_number,
+        block_hash,
+        modified_timestamp AS _modified_timestamp
+    FROM
+        {{ ref('silver__blocks') }}
+    WHERE
+        block_number >= 767430
+        AND NOT is_pending
+
+{% if is_incremental() %}
+AND (
+    _modified_timestamp >= (
+        SELECT
+            MAX(_modified_timestamp)
+        FROM
+            {{ this }}
+    )
+    OR block_number > (
+        SELECT
+            MAX(block_number)
+        FROM
+            {{ this }}
+        WHERE
+            status_code = 200
+    )
+)
+{% endif %}
+ORDER BY
+    block_number ASC
+LIMIT
+    100
+),
+get_inscription_count AS (
+    SELECT
+        block_number,
+        block_hash,
+        _modified_timestamp,
+        SYSDATE() AS _request_timestamp,
+        {{ target.database }}.live.udf_api(
+            'GET',
+            'https://api.hiro.so/ordinals/v1/inscriptions/transfers?block=' || block_hash || '&limit=1',
+            {},
+            OBJECT_CONSTRUCT(
+                'Accept',
+                'application/json',
+                'x-hiro-api-key',
+                'db2c8f0f3262113265682c15636bc775' -- TODO move to vault
+            )
+        ) AS response
+    FROM
+        blocks
+)
+SELECT
+    block_number,
+    block_hash,
+    response :data :total :: NUMBER AS inscription_count,
+    response :status_code :: NUMBER AS status_code,
+    _request_timestamp,
+    _modified_timestamp,
+    SYSDATE() AS inserted_timestamp,
+    SYSDATE() AS modified_timestamp,
+    '{{ invocation_id }}' AS _invocation_id
+FROM
+    get_inscription_count


### PR DESCRIPTION
Queries [transfers per block endpoint](https://docs.hiro.so/ordinals/transfers-per-block) to create a spine of block height, block hash and inscription transfer count for use in full integration. Max limit is 60 transfers per call, so this model gives us the total number of transfers in a block to determine max requests per block.

100 successful runs per call * 10 per workflow kickoff * 4 per hour = 4,000 blocks per hour. With ~74,000 blocks to log, this should finish in 18.5hrs.